### PR TITLE
DOC: add "Archived" warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,4 @@
-# Pyright mirror
+# Pyright pre-commit mirror
 
-Mirror of [Pyright](https://github.com/microsoft/pyright) for
-[pre-commit](https://pre-commit.com), created with
-[`pre-commit-mirror-maker`](https://github.com/pre-commit/pre-commit-mirror-maker).
-See
-[github.com/pre-commit/mirrors-prettier](https://github.com/pre-commit/mirrors-prettier)
-for an example of a pre-commit hook for a Node.js package.
-
-### Using Pyright with pre-commit
-
-Add this to your `.pre-commit-config.yaml`:
-
-```yaml
-- repo: https://github.com/ComPWA/mirrors-pyright
-  rev: ""
-  hooks:
-    - id: pyright
-```
-
-then run `pre-commit autoupdate`.
+> [!WARNING]
+> This repository has been archived and is no longer maintained. Please use the [pre-commit hook](https://github.com/RobertCraigie/pyright-python?tab=readme-ov-file#pre-commit) offered by [RobertCraigie/pyright-python](https://github.com/RobertCraigie/pyright-python) instead.


### PR DESCRIPTION
> [!WARNING]
> This repository has been archived and is no longer maintained. Please use the [pre-commit hook](https://github.com/RobertCraigie/pyright-python?tab=readme-ov-file#pre-commit) offered by [RobertCraigie/pyright-python](https://github.com/RobertCraigie/pyright-python) instead.